### PR TITLE
fix show round not working for some arrays types

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -17,7 +17,7 @@ function Base.show(io::IO, ::MIME"text/plain", A::UnivariateStatistic{T, K, I}) 
     if I <: Integer
         print(io, "  nobs: $n")
     else
-        print(io, "  weight: $(round(n; sigdigits = sig_digits))")
+        print(io, "  weight: $(round.(n; sigdigits = sig_digits))")
     end
 
     if n == 0


### PR DESCRIPTION
with certain arrays it does not work if you don't explicitly broadcast

WAIT. could be something weird from my tests 