### PR TITLE
uniform weights for FITS i/o

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+- Write uniform weights as one-cell arrays in FITS files i/o
+
 ## [0.3.2] - 2026-03-18
 
 - Set function `find_stat_hdus` public (it was private to the extension).

--- a/ext/OnlineSampleStatisticsAstroFITSExt.jl
+++ b/ext/OnlineSampleStatisticsAstroFITSExt.jl
@@ -1,13 +1,13 @@
 module OnlineSampleStatisticsAstroFITSExt
 
 if isdefined(Base, :get_extension)
-    using OnlineSampleStatistics, AstroFITS
+    using OnlineSampleStatistics, AstroFITS, StructuredArrays
     import OnlineSampleStatistics: isa_stat_hdu, find_stat_group_ids, find_stat_hdus,
         STAT_HDU_KWD, STAT_GROUP_ID_KWD, STAT_MOMENT_INDEX_KWD,
         STAT_NB_MOMENTS_KWD, STAT_WEIGHTS_KWD
     import Base: read, write
 else
-    using ..OnlineSampleStatistics, ..AstroFITS
+    using ..OnlineSampleStatistics, ..AstroFITS, ..StructuredArrays
     import ..OnlineSampleStatistics: isa_stat_hdu, find_stat_group_ids, find_stat_hdus,
         STAT_HDU_KWD, STAT_GROUP_ID_KWD, STAT_MOMENT_INDEX_KWD,
         STAT_NB_MOMENTS_KWD, STAT_WEIGHTS_KWD
@@ -110,7 +110,9 @@ function Base.write(
         write(moments_hdus[k], OnlineSampleStatistics.get_rawmoments(stat, k))
     end
 
-    weights_hdu = FitsImageHDU{W, N}(file, dims)
+    # if the weights are uniform, we will write an Array{T,N} with only one cell
+    is_uniform = (nobs(stat) isa AbstractUniformArray)
+    weights_hdu = FitsImageHDU{W, N}(file, is_uniform ? ntuple(_ -> 1, N) : dims)
     merge!(
         weights_hdu, FitsHeader(
             STAT_HDU_KWD => (true, "is a OnlineSampleStatistics.jl data"),
@@ -120,7 +122,11 @@ function Base.write(
     )
     # adding EXTNAME unless the user already specified one
     haskey(weights_hdu, "EXTNAME") || push!(weights_hdu, "EXTNAME" => "WEIGHTS")
-    write(weights_hdu, nobs(stat))
+    if is_uniform
+        write(weights_hdu, fill(first(nobs(stat)), ntuple(_ -> 1, N)))
+    else
+        write(weights_hdu, nobs(stat))
+    end
 
     return file
 end
@@ -198,6 +204,11 @@ function Base.read(
 
     moments = NTuple{K, Array{T, N}}(read(Array{T, N}, moments_hdus[k]) for k in 1:K)
     weights = read(Array{W, N}, weights_hdu; readkwds...)
+
+    # handle uniform weights stored as one-cell array
+    if length(weights) == 1
+        weights = MutableUniformArray(first(weights), size(moments[1]))
+    end
 
     return OnlineSampleStatistics.build_from_rawmoments(weights, moments)
 end

--- a/test/OnlineSampleStatisticsAstroFITSExt_test.jl
+++ b/test/OnlineSampleStatisticsAstroFITSExt_test.jl
@@ -164,6 +164,14 @@ Ext = Base.get_extension(OnlineSampleStatistics, :OnlineSampleStatisticsAstroFIT
             @test_throws err FitsFile(f -> read(IndependentStatistic, f), fitsfile2_path)
         end
 
+        @testset "read/write with non uniform weights" begin
+            stat_group_id = "non uni weights"
+            non_uni_stat = IndependentStatistic(2, rand(Float32,3,3,10), rand(1:100,3,3,10); dims=3)
+            @test_nowarn write(fitsfile, FitsHeader(), non_uni_stat, stat_group_id)
+            @test_nowarn read(IndependentStatistic, fitsfile, stat_group_id)
+            @test read(IndependentStatistic, fitsfile, stat_group_id) == non_uni_stat
+        end
+
         try
             close(fitsfile)
         catch err


### PR DESCRIPTION
- I was systematically writing weights as full matrices in FITS files.
- weights, even uniform, were then always converted to full matrices
- this was a waste of space, and even waste of speed I think
- this PR changes this
- uniform arrays are written as one-cell arrays in FITS files
- they are converted back to MutableUniformArray when read
- even if the array has length of one, I kept the number of dimension, mostly because DS9 is unable to read 1-dimension arrays

what do you think ?